### PR TITLE
Devops/link back front together

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -6,6 +6,24 @@ resource "aws_alb" "main" {
   security_groups = [aws_security_group.lb.id]
 }
 
+resource "aws_alb_target_group" "backend_app" {
+  name        = "cb-backend-group"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = var.health_check_backend_path
+    unhealthy_threshold = "2"
+  }
+}
+
 resource "aws_alb_target_group" "app" {
   name        = "cb-target-group"
   port        = 80
@@ -33,5 +51,20 @@ resource "aws_alb_listener" "front_end" {
   default_action {
     target_group_arn = aws_alb_target_group.app.id
     type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_rule" "back_end" {
+  listener_arn = "${aws_alb_listener.front_end.arn}"
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.backend_app.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/api/*"]
   }
 }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -5,9 +5,10 @@ resource "aws_ecs_cluster" "main" {
 }
 
 data "template_file" "cb_app" {
-  template = file("./templates/ecs/cb_app.json.tpl")
+  template = file("./templates/ecs/ecs-task-definition.json.tpl")
 
   vars = {
+    container_name = "cb-app"
     app_image      = var.app_image
     app_port       = var.app_port
     fargate_cpu    = var.fargate_cpu
@@ -43,6 +44,51 @@ resource "aws_ecs_service" "main" {
     target_group_arn = aws_alb_target_group.app.id
     container_name   = "cb-app"
     container_port   = var.app_port
+  }
+
+  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]
+}
+
+data "template_file" "cb_app_backend" {
+  template = file("./templates/ecs/ecs-task-definition.json.tpl")
+
+  vars = {
+    container_name = "cb-app-backend"
+    app_image      = var.app_backend_image
+    app_port       = var.app_backend_port
+    fargate_cpu    = var.fargate_cpu
+    fargate_memory = var.fargate_memory
+    aws_region     = var.aws_region
+  }
+}
+
+resource "aws_ecs_task_definition" "app_backend" {
+  family                   = "cb-app-backend-task"
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  container_definitions    = data.template_file.cb_app_backend.rendered
+}
+
+resource "aws_ecs_service" "backend" {
+  name            = "cb-service-backend"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app_backend.arn
+  desired_count   = var.app_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = aws_subnet.private.*.id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.backend_app.id
+    container_name   = "cb-app-backend"
+    container_port   = var.app_backend_port
   }
 
   depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -8,8 +8,8 @@ resource "aws_security_group" "lb" {
 
   ingress {
     protocol    = "tcp"
-    from_port   = var.app_port
-    to_port     = var.app_port
+    from_port   = var.lb_port
+    to_port     = var.lb_port
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -31,6 +31,13 @@ resource "aws_security_group" "ecs_tasks" {
     protocol        = "tcp"
     from_port       = var.app_port
     to_port         = var.app_port
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.app_backend_port
+    to_port     = var.app_backend_port
     security_groups = [aws_security_group.lb.id]
   }
 

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,6 +1,6 @@
-resource "aws_s3_bucket" "app_state" {
-  bucket = "codurance-openspace-app-state"
-}
+// resource "aws_s3_bucket" "app_state" {
+//  bucket = "codurance-openspace-app-state"
+// }
 
 terraform {
   backend "s3" {

--- a/terraform/templates/ecs/ecs-task-definition.json.tpl
+++ b/terraform/templates/ecs/ecs-task-definition.json.tpl
@@ -1,6 +1,6 @@
 [
   {
-    "name": "cb-app",
+    "name": "${container_name}",
     "image": "${app_image}",
     "cpu": ${fargate_cpu},
     "memory": ${fargate_memory},

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,6 +3,11 @@ variable "aws_region" {
   default     = "eu-west-2"
 }
 
+variable "lb_port" {
+  description = "Port exposed by the load balancer to listen to internet traffic"
+  default     = 80
+}
+
 variable "ecs_task_execution_role_name" {
   description = "ECS task execution role name"
   default = "myEcsTaskExecutionRole"
@@ -20,12 +25,22 @@ variable "az_count" {
 
 variable "app_image" {
   description = "Docker image to run in the ECS cluster"
-  default     = "codurance/open-space:6385445313ff0c51487de45955e5f67513e10424"
+  default     = "codurance/open-space"
 }
 
 variable "app_port" {
   description = "Port exposed by the docker image to redirect traffic to"
   default     = 80
+}
+
+variable "app_backend_image" {
+  description = "Docker backend image to run in the ECS cluster"
+  default     = "codurance/open-space-backend"
+}
+
+variable "app_backend_port" {
+  description = "Port exposed by the backend docker image to redirect traffic to"
+  default     = 8080
 }
 
 variable "app_count" {
@@ -35,6 +50,10 @@ variable "app_count" {
 
 variable "health_check_path" {
   default = "/"
+}
+
+variable "health_check_backend_path" {
+  default = "/api"
 }
 
 variable "fargate_cpu" {


### PR DESCRIPTION
Resolves #6 
Add backend task definition and all related resources to terraform

1. new variables in variables.tf to specify port/image for backend
2. change task definition template file name, and make "name" configurable
3. add backend ecs task in ecs.tf
4. add backend target group in alb.tf
5. add new rule to load balancer to forward traffic starts with "/api/*" to backend target group
6. use "/api" as health check link for backend for now, need to change it to a long term solution
7. add 8080 port to ingress rule of ecs tasks group in security.tf
8. remove bucket creation from state.tf since it should be created manually before script is run
9. add default region (eu-west-2) to provider.tf

