### PR TITLE
Backend - GET and POST Requests, H2 DB

### DIFF
--- a/packages/backend/build.gradle
+++ b/packages/backend/build.gradle
@@ -16,6 +16,7 @@ repositories {
 
 ext {
     junitVersion = '5.5.2'
+    mockitoVersion = '3.0.0'
 }
 
 configurations {
@@ -25,11 +26,15 @@ configurations {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 wrapper {

--- a/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSession.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSession.java
@@ -1,0 +1,23 @@
+package com.codurance.open_space;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "sessions")
+public class OpenSpaceSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    private String title;
+    private String location;
+    private String time;
+    private String presenter;
+}

--- a/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionController.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionController.java
@@ -20,6 +20,7 @@ public class OpenSpaceSessionController {
     }
 
     @ResponseStatus(CREATED)
+    @CrossOrigin
     @PostMapping
     public OpenSpaceSession create(@RequestBody OpenSpaceSession openSpaceSession) {
         return repository.save(openSpaceSession);

--- a/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionController.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionController.java
@@ -1,0 +1,21 @@
+package com.codurance.open_space;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("sessions")
+public class OpenSpaceSessionController {
+
+    private final OpenSpaceSessionRepository repository;
+
+    @GetMapping
+    public List<OpenSpaceSession> getAllOpenSpaceSessions() {
+        return repository.findAll();
+    }
+}

--- a/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionController.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionController.java
@@ -1,15 +1,15 @@
 package com.codurance.open_space;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.*;
+
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("sessions")
+@RequestMapping("/api/sessions")
 public class OpenSpaceSessionController {
 
     private final OpenSpaceSessionRepository repository;
@@ -17,5 +17,11 @@ public class OpenSpaceSessionController {
     @GetMapping
     public List<OpenSpaceSession> getAllOpenSpaceSessions() {
         return repository.findAll();
+    }
+
+    @ResponseStatus(CREATED)
+    @PostMapping
+    public OpenSpaceSession create(@RequestBody OpenSpaceSession openSpaceSession) {
+        return repository.save(openSpaceSession);
     }
 }

--- a/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionRepository.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/OpenSpaceSessionRepository.java
@@ -1,0 +1,8 @@
+package com.codurance.open_space;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OpenSpaceSessionRepository extends JpaRepository<OpenSpaceSession, Integer> {
+}

--- a/packages/backend/src/main/resources/application.yml
+++ b/packages/backend/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: "/h2"
+  datasource:
+    url: "jdbc:h2:mem:testdb"
+    driverClassName: org.h2.Driver
+    username: user
+    password: password

--- a/packages/backend/src/main/resources/data.sql
+++ b/packages/backend/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+insert into sessions (title, location, time, presenter)
+values ('Session 1', 'Location 1', '11:00', 'David');
+
+insert into sessions (title, location, time, presenter)
+values ('Session 2', 'Location 2', '13:00', 'Andrei');
+
+insert into sessions (title, location, time, presenter)
+values ('Session 3', 'Location 3', '14:00', 'Sherlock');
+
+insert into sessions (title, location, time, presenter)
+values ('Session 4', 'Location 4', '14:00', 'Tacuma');

--- a/packages/backend/src/test/java/com/codurance/open_space/OpenSpaceSessionControllerShould.java
+++ b/packages/backend/src/test/java/com/codurance/open_space/OpenSpaceSessionControllerShould.java
@@ -1,0 +1,42 @@
+package com.codurance.open_space;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OpenSpaceSessionController.class)
+public class OpenSpaceSessionControllerShould {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OpenSpaceSessionRepository repository;
+
+    @Test
+    void return_all_open_space_sessions_from_the_h2_db() throws Exception {
+        when(repository.findAll()).thenReturn(
+                List.of(new OpenSpaceSession(
+                        1,
+                        "Session 1",
+                        "Location 1",
+                        "11:00",
+                        "David")));
+
+        mockMvc.perform(get("/sessions")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("[{\"id\":1,\"title\":\"Session 1\",\"location\":\"Location 1\",\"time\":\"11:00\",\"presenter\":\"David\"}]"));
+    }
+}

--- a/packages/backend/src/test/java/com/codurance/open_space/OpenSpaceSessionControllerShould.java
+++ b/packages/backend/src/test/java/com/codurance/open_space/OpenSpaceSessionControllerShould.java
@@ -1,6 +1,7 @@
 package com.codurance.open_space;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,46 +25,36 @@ public class OpenSpaceSessionControllerShould {
     @MockBean
     private OpenSpaceSessionRepository repository;
 
+    private OpenSpaceSession openSpaceSession;
+    private static final String API_PATH = "/api/sessions";
+
+    @BeforeEach
+    void setUp() {
+        openSpaceSession = new OpenSpaceSession(1, "Session 1", "Location 1", "11:00", "David");
+    }
+
     @Test
     void get_all_open_space_sessions_from_the_repository() throws Exception {
-        when(repository.findAll()).thenReturn(
-                List.of(new OpenSpaceSession(
-                        1,
-                        "Session 1",
-                        "Location 1",
-                        "11:00",
-                        "David")));
+        final String expectedJson = "[{\"id\":1,\"title\":\"Session 1\",\"location\":\"Location 1\",\"time\":\"11:00\",\"presenter\":\"David\"}]";
 
-        mockMvc.perform(get("/api/sessions")
+        when(repository.findAll())
+                .thenReturn(List.of(openSpaceSession));
+
+        mockMvc.perform(get(API_PATH)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().json("[{\"id\":1,\"title\":\"Session 1\",\"location\":\"Location 1\",\"time\":\"11:00\",\"presenter\":\"David\"}]"));
+                .andExpect(content().json(expectedJson));
     }
 
     @Test
     void post_open_space_session() throws Exception {
-        when(repository.save(new OpenSpaceSession(
-                1,
-                "Session 1",
-                "Location 1",
-                "11:00",
-                "David")))
-                .thenReturn(new OpenSpaceSession(
-                        1,
-                        "Session 1",
-                        "Location 1",
-                        "11:00",
-                        "David"));
+        when(repository.save(openSpaceSession))
+                .thenReturn(openSpaceSession);
 
-        mockMvc.perform(post("/api/sessions")
-                .content(asJsonString(new OpenSpaceSession(
-                        1,
-                        "Session 1",
-                        "Location 1",
-                        "11:00",
-                        "David")))
+        mockMvc.perform(post(API_PATH)
+                .content(asJsonString(openSpaceSession))
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())

--- a/packages/backend/src/test/java/com/codurance/open_space/OpenSpaceSessionControllerShould.java
+++ b/packages/backend/src/test/java/com/codurance/open_space/OpenSpaceSessionControllerShould.java
@@ -1,5 +1,6 @@
 package com.codurance.open_space;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,6 +12,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(OpenSpaceSessionController.class)
@@ -23,7 +25,7 @@ public class OpenSpaceSessionControllerShould {
     private OpenSpaceSessionRepository repository;
 
     @Test
-    void return_all_open_space_sessions_from_the_h2_db() throws Exception {
+    void get_all_open_space_sessions_from_the_repository() throws Exception {
         when(repository.findAll()).thenReturn(
                 List.of(new OpenSpaceSession(
                         1,
@@ -32,11 +34,51 @@ public class OpenSpaceSessionControllerShould {
                         "11:00",
                         "David")));
 
-        mockMvc.perform(get("/sessions")
+        mockMvc.perform(get("/api/sessions")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json("[{\"id\":1,\"title\":\"Session 1\",\"location\":\"Location 1\",\"time\":\"11:00\",\"presenter\":\"David\"}]"));
+    }
+
+    @Test
+    void post_open_space_session() throws Exception {
+        when(repository.save(new OpenSpaceSession(
+                1,
+                "Session 1",
+                "Location 1",
+                "11:00",
+                "David")))
+                .thenReturn(new OpenSpaceSession(
+                        1,
+                        "Session 1",
+                        "Location 1",
+                        "11:00",
+                        "David"));
+
+        mockMvc.perform(post("/api/sessions")
+                .content(asJsonString(new OpenSpaceSession(
+                        1,
+                        "Session 1",
+                        "Location 1",
+                        "11:00",
+                        "David")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("Session 1"))
+                .andExpect(jsonPath("$.location").value("Location 1"))
+                .andExpect(jsonPath("$.time").value("11:00"))
+                .andExpect(jsonPath("$.presenter").value("David"));
+    }
+
+    private static String asJsonString(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
     }
 }


### PR DESCRIPTION
Resolves #9 
Resolves #29 
Resolves #15 

- Added in memory h2 database.
- Added POST mapping and test for creating a Session in the h2 database.
- Added GET mapping and test for getting all Sessions from the h2 database.
- Added CrossOrigin annotation to the POST mapping api. The annotation has to be removed after we finish the initial stage of the project. It is there for debugging requests from a localhost client (the React app in the browser in our case).