### PR TITLE
use polyfill as a fallback in production code

### DIFF
--- a/packages/frontend/app/cypress/support/index.js
+++ b/packages/frontend/app/cypress/support/index.js
@@ -21,3 +21,9 @@ import "./commands";
 Cypress.Screenshot.defaults({
   screenshotOnRunFailure: false
 });
+
+// disable fetch so that a polyfill will takeover by using xhr
+// to support Cypress.server/route/wait
+Cypress.on("window:before:load", win => {
+  delete win.fetch;
+});

--- a/packages/frontend/app/cypress/tsconfig.json
+++ b/packages/frontend/app/cypress/tsconfig.json
@@ -6,5 +6,5 @@
     "lib": ["es5", "dom"],
     "types": ["cypress"]
   },
-  "include": ["**/*.ts", "../src/common/whatwg-fetch.d.ts"]
+  "include": ["**/*.ts"]
 }

--- a/packages/frontend/app/src/common/http.ts
+++ b/packages/frontend/app/src/common/http.ts
@@ -1,4 +1,4 @@
-import { fetch } from "whatwg-fetch";
+import "whatwg-fetch"; // work as a fallback to polyfill in old browser, but mostly for using xhr in cypress
 
 export interface IHttpResponse<T> extends Response {
   parsedBody?: T;

--- a/packages/frontend/app/src/common/whatwg-fetch.d.ts
+++ b/packages/frontend/app/src/common/whatwg-fetch.d.ts
@@ -1,1 +1,0 @@
-declare module "whatwg-fetch";


### PR DESCRIPTION
1. use polyfill as a fallback in production code
2. override in cypress to activate it
3. ts declaration no longer required