### PR TITLE
enforce an tsc check before running test, fix front-end test; and provide a way to mock useContext

### DIFF
--- a/packages/frontend/app/package.json
+++ b/packages/frontend/app/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
-    "test:ci": "CI=true react-scripts test --env=jsdom",
+    "test": "tsc && react-scripts test",
+    "test:ci": "tsc && CI=true react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "cypress-run": "cypress run"
   },

--- a/packages/frontend/app/src/session/Session.test.tsx
+++ b/packages/frontend/app/src/session/Session.test.tsx
@@ -20,8 +20,6 @@ beforeEach(() => {
       presenter={presenter}
       location={location}
       time={time}
-      onEditClicked={jest.fn()}
-      isEditing={false}
     />
   );
 });

--- a/packages/frontend/app/src/session/Sessions.test.tsx
+++ b/packages/frontend/app/src/session/Sessions.test.tsx
@@ -1,21 +1,14 @@
 import React from "react";
 import Sessions from "./Sessions";
-import { Session } from "./Session";
 import enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { any } from "prop-types";
+import * as SessionsContext from "./sessionsContext";
+import { Session } from "./Session";
 enzyme.configure({ adapter: new Adapter() });
 
 it("Renders sessions when sessions exist", () => {
-  const wrapper = enzyme.shallow(
-    <Sessions
-      sessions={[]}
-      isEditing={false}
-      setIsEditing={jest.fn()}
-      setSessionToEdit={jest.fn()}
-      getSessions={jest.fn()}
-    />
-  );
+  const wrapper = enzyme.shallow(<Sessions isFilteringByInterest={false} />);
 
   const sessionElementChildren = wrapper.find(any);
 
@@ -23,23 +16,24 @@ it("Renders sessions when sessions exist", () => {
 });
 
 it("Renders sessions when sessions exist", () => {
-  const wrapper = enzyme.shallow(
-    <Sessions
-      sessions={[
-        {
-          id: 0,
-          title: "title",
-          location: "location",
-          time: "12:00",
-          presenter: "presenter"
-        }
-      ]}
-      isEditing={false}
-      setIsEditing={jest.fn()}
-      setSessionToEdit={jest.fn()}
-      getSessions={jest.fn()}
-    />
-  );
+  const sessions: SessionsContext.ISession[] = [
+    {
+      id: 0,
+      title: "title",
+      location: "location",
+      time: "12:00",
+      presenter: "presenter"
+    }
+  ];
+
+  jest.spyOn(SessionsContext, "useSessionsContext").mockImplementation(() => ({
+    sessions: sessions,
+    setSessions: jest.fn(),
+    currentSession: undefined,
+    setCurrentSession: jest.fn()
+  }));
+
+  const wrapper = enzyme.shallow(<Sessions isFilteringByInterest={false} />);
 
   const doesContainSession = wrapper.contains(
     <Session
@@ -50,6 +44,5 @@ it("Renders sessions when sessions exist", () => {
       time="12:00"
     />
   );
-  // FIXME: can't find a way to fix it for now
-  // expect(doesContainSession).toBe(true);
+  expect(doesContainSession).toBe(true);
 });

--- a/packages/frontend/app/src/session/Sessions.tsx
+++ b/packages/frontend/app/src/session/Sessions.tsx
@@ -1,6 +1,9 @@
-import React, { useContext } from "react";
+import React from "react";
 import { Session } from "./Session";
-import SessionsContext, { ISession } from "./sessionsContext";
+import SessionsContext, {
+  ISession,
+  useSessionsContext
+} from "./sessionsContext";
 import * as sessionStorage from "../common/sessionsLocalStorage";
 
 interface SessionsProps {
@@ -8,7 +11,8 @@ interface SessionsProps {
 }
 
 const Sessions: React.FC<SessionsProps> = props => {
-  const { sessions } = useContext(SessionsContext);
+  // const { sessions } = useContext(SessionsContext);
+  const { sessions } = useSessionsContext();
 
   const bySessionTime = function(a: ISession, b: ISession) {
     if (a.time < b.time) return -1;

--- a/packages/frontend/app/src/session/sessionsContext.ts
+++ b/packages/frontend/app/src/session/sessionsContext.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 
 export interface ISession {
   id: number;
@@ -22,4 +22,5 @@ const SessionsContext = React.createContext<ISessionsContext>({
   setCurrentSession: () => {}
 });
 
+export const useSessionsContext = () => useContext(SessionsContext);
 export default SessionsContext;


### PR DESCRIPTION
Resolves #121 
### ways to mock useContext
the trick is to move useContext of react into our own module, and call that instead to make it mockable.

```
import * as SessionsContext from "./sessionsContext";
...
const sessions: SessionsContext.ISession[] = [
    {
      id: 0,
      title: "title",
      location: "location",
      time: "12:00",
      presenter: "presenter"
    }
  ];

  jest
    .spyOn(SessionsContext, "useSessionsContext")
    .mockImplementation(() => ({
    sessions: sessions,
    setSessions: jest.fn(),
    currentSession: undefined,
    setCurrentSession: jest.fn()
  }));

```