### PR TITLE
Add session type to session in backend

### DIFF
--- a/packages/backend/src/main/java/com/codurance/open_space/controller/ErrorResponse.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/controller/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.codurance.open_space.controller;
+
+class ErrorResponse {
+    private String message;
+
+    ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/packages/backend/src/main/java/com/codurance/open_space/controller/SessionController.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/controller/SessionController.java
@@ -28,14 +28,14 @@ public class SessionController {
     public ResponseEntity<?> create(@RequestBody Session session) {
         try {
             return new ResponseEntity<>(repository.save(session), CREATED);
-        }catch(DataIntegrityViolationException e) {
+        } catch (DataIntegrityViolationException e) {
 
             return new ResponseEntity<>(new ErrorResponse("Session type is required"), BAD_REQUEST);
         }
     }
 
     @PutMapping("/{id}")
-    public Session update(@PathVariable int id, @RequestBody Session openSpaceSession) {
+    public ResponseEntity<?> update(@PathVariable int id, @RequestBody Session openSpaceSession) {
         Session session = repository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
 
@@ -43,12 +43,17 @@ public class SessionController {
         session.setPresenter(openSpaceSession.getPresenter());
         session.setTime(openSpaceSession.getTime());
         session.setTitle(openSpaceSession.getTitle());
-        return repository.save(session);
+        session.setType(openSpaceSession.getType());
+        try {
+            return new ResponseEntity<>(repository.save(session), OK);
+        } catch (DataIntegrityViolationException e) {
+            return new ResponseEntity<>(new ErrorResponse("Session type is required"), BAD_REQUEST);
+        }
     }
 
     @ResponseStatus(NO_CONTENT)
     @DeleteMapping("/{id}")
-    public void deleteById(@PathVariable int id){
+    public void deleteById(@PathVariable int id) {
         repository.deleteById(id);
     }
 }

--- a/packages/backend/src/main/java/com/codurance/open_space/controller/SessionController.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/controller/SessionController.java
@@ -3,13 +3,14 @@ package com.codurance.open_space.controller;
 import com.codurance.open_space.domain.Session;
 import com.codurance.open_space.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -23,11 +24,14 @@ public class SessionController {
         return repository.findAll();
     }
 
-    @ResponseStatus(CREATED)
-    @CrossOrigin
     @PostMapping
-    public Session create(@RequestBody Session session) {
-        return repository.save(session);
+    public ResponseEntity<?> create(@RequestBody Session session) {
+        try {
+            return new ResponseEntity<>(repository.save(session), CREATED);
+        }catch(DataIntegrityViolationException e) {
+
+            return new ResponseEntity<>(new ErrorResponse("Session type is required"), BAD_REQUEST);
+        }
     }
 
     @PutMapping("/{id}")

--- a/packages/backend/src/main/java/com/codurance/open_space/domain/Session.java
+++ b/packages/backend/src/main/java/com/codurance/open_space/domain/Session.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 @Data
 @AllArgsConstructor
@@ -21,4 +22,7 @@ public class Session {
     private Space location;
     private String time;
     private String presenter;
+    @NotNull
+    private String type;
+
 }

--- a/packages/backend/src/main/resources/data.sql
+++ b/packages/backend/src/main/resources/data.sql
@@ -4,15 +4,15 @@ values (1, 'Name 1', 'Big size space with 10 chairs, aircon, and TV', '3rd floor
 insert into spaces (id, name, description, location)
 values (2, 'Name 2', 'Tiny room with no windows', '4th floor');
 
-insert into sessions (title, location_id, time, presenter)
-values ('Session 1', 1, '11:00', 'David');
+insert into sessions (title, location_id, time, presenter, type)
+values ('Session 1', 1, '11:00', 'David', 'Round Table');
 
-insert into sessions (title, location_id, time, presenter)
-values ('Session 2', 1, '13:00', 'Andrei');
+insert into sessions (title, location_id, time, presenter, type)
+values ('Session 2', 1, '13:00', 'Andrei', 'Lecture');
 
-insert into sessions (title, location_id, time, presenter)
-values ('Session 3', 2, '14:00', 'Sherlock');
+insert into sessions (title, location_id, time, presenter, type)
+values ('Session 3', 2, '14:00', 'Sherlock', 'Mobbing');
 
-insert into sessions (title, location_id, time, presenter)
-values ('Session 4', 2, '14:00', 'Tacuma');
+insert into sessions (title, location_id, time, presenter, type)
+values ('Session 4', 2, '14:00', 'Tacuma', 'Round Table');
 

--- a/packages/backend/src/test/java/com/codurance/open_space/SessionControllerShould.java
+++ b/packages/backend/src/test/java/com/codurance/open_space/SessionControllerShould.java
@@ -158,15 +158,6 @@ public class SessionControllerShould {
         verify(repository).deleteById(1);
     }
 
-    /*
-    {
-        status: 400,
-        httpMessage: Bad Request,
-        apiStatusCode: 215,
-        message: Zip code format is not valid, it must be a 5 digit number,
-        description: Could not process the request.
-}
-     */
     @Test
     void give_error_message_when_session_type_is_missing() throws Exception{
 
@@ -176,6 +167,32 @@ public class SessionControllerShould {
         try {
             mockMvc.perform(post("/api/sessions")
                     .content(asJsonString(session))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("Session type is required"));
+        }catch (Exception e) {
+            Assertions.fail("controller should not throw exception");
+        }
+    }
+
+    @Test
+    void give_error_message_when_session_type_is_missing_when_update_session() throws Exception{
+
+        when(repository.findById(1)).thenReturn(Optional.of(session));
+        Session sessionWithNullType = new Session();
+        sessionWithNullType.setId(session.getId());
+        sessionWithNullType.setTitle(session.getTitle());
+        sessionWithNullType.setLocation(session.getLocation());
+        sessionWithNullType.setTime(session.getTime());
+        sessionWithNullType.setPresenter(session.getPresenter());
+        sessionWithNullType.setType(null);
+
+        when(repository.save(sessionWithNullType)).thenThrow(new DataIntegrityViolationException("session type is not-null"));
+
+        try {
+            mockMvc.perform(put("/api/sessions/1")
+                    .content(asJsonString(sessionWithNullType))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())


### PR DESCRIPTION
Resolves #106 

1. We don't have a pre-defined list in backend, we decided that to only be in front end
2. Add type field in session
3. Have a null check for session type. If it's null, a BAD_REQUEST response would be returned for POST and PUT